### PR TITLE
Pre-reqs, README tidy

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,26 +8,29 @@ my $builder = Module::Build->new(
     dist_author         => q{Sam Graham <libpod-weaver-pluginbundle-replaceboilerplate-perl@illusori.co.uk>},
     dist_version_from   => 'lib/Pod/Weaver/PluginBundle/ReplaceBoilerplate.pm',
     build_requires => {
-        'Test::More' => 0,
+        'PPI'               => 0,
+        'Test::More'        => 0,
+        'Test::Differences' => 0,
     },
     add_to_cleanup      => [ 'Pod-Weaver-PluginBundle-ReplaceBoilerplate-*' ],
     requires       => {
         'Moose'          => 0,
         'Moose::Autobox' => '0.11',
         'Pod::Elemental' => '0.101620',
-        'Pod::Weaver'    => '3.101630',
+        'Pod::Weaver'    => '3.101632',
         'Pod::Weaver::Role::SectionReplacer' => 0,
         'Software::License' => 0,
         'namespace::autoclean' => 0,
     },
     meta_merge => {
         'resources' => {
-            'repository' => 'http://github.com/illusori/Perl-Pod-Weaver-PluginBundle-ReplaceBoilerplate',
+            'repository' => 'https://github.com/illusori/Perl-Pod-Weaver-PluginBundle-ReplaceBoilerplate',
             },
         },
     create_readme => 1,
     sign => 1,
     dynamic_config => 0,
+    bugtracker => "https://github.com/illusori/Perl-Pod-Weaver-PluginBundle-ReplaceBoilerplate/issues"
 );
 
 $builder->create_build_script();

--- a/META.yml
+++ b/META.yml
@@ -3,41 +3,41 @@ abstract: 'A Pod::Weaver bundle for replacing the boilerplate in a Pod document.
 author:
   - 'Sam Graham <libpod-weaver-pluginbundle-replaceboilerplate-perl@illusori.co.uk>'
 build_requires:
-  Test::More: 0
+  Test::More: '0'
 configure_requires:
-  Module::Build: 0.36
+  Module::Build: '0.42'
 dynamic_config: 0
-generated_by: 'Module::Build version 0.3607'
+generated_by: 'Module::Build version 0.4211, CPAN::Meta::Converter version 2.143240'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
-  version: 1.4
+  version: '1.4'
 name: Pod-Weaver-PluginBundle-ReplaceBoilerplate
 provides:
   Pod::Weaver::PluginBundle::ReplaceBoilerplate:
     file: lib/Pod/Weaver/PluginBundle/ReplaceBoilerplate.pm
-    version: 1.00
+    version: 1.00_01
   Pod::Weaver::Section::ReplaceAuthors:
     file: lib/Pod/Weaver/Section/ReplaceAuthors.pm
-    version: 1.00
+    version: 1.00_01
   Pod::Weaver::Section::ReplaceLegal:
     file: lib/Pod/Weaver/Section/ReplaceLegal.pm
-    version: 1.00
+    version: 1.00_01
   Pod::Weaver::Section::ReplaceName:
     file: lib/Pod/Weaver/Section/ReplaceName.pm
-    version: 1.00
+    version: 1.00_01
   Pod::Weaver::Section::ReplaceVersion:
     file: lib/Pod/Weaver/Section/ReplaceVersion.pm
-    version: 1.00
+    version: 1.00_01
 requires:
-  Moose: 0
-  Moose::Autobox: 0.11
-  Pod::Elemental: 0.101620
-  Pod::Weaver: 3.101632
-  Pod::Weaver::Role::SectionReplacer: 0
-  Software::License: 0
+  Moose: '0'
+  Moose::Autobox: '0.11'
+  Pod::Elemental: '0.101620'
+  Pod::Weaver: '3.101632'
+  Pod::Weaver::Role::SectionReplacer: '0'
+  Software::License: '0'
+  namespace::autoclean: '0'
 resources:
   license: http://dev.perl.org/licenses/
   repository: http://github.com/illusori/Perl-Pod-Weaver-PluginBundle-ReplaceBoilerplate
 version: 1.00_01
-

--- a/META.yml
+++ b/META.yml
@@ -33,7 +33,7 @@ requires:
   Moose: 0
   Moose::Autobox: 0.11
   Pod::Elemental: 0.101620
-  Pod::Weaver: 3.101630
+  Pod::Weaver: 3.101632
   Pod::Weaver::Role::SectionReplacer: 0
   Software::License: 0
 resources:

--- a/README
+++ b/README
@@ -1,28 +1,32 @@
 NAME
-    Pod::Weaver::PluginBundle::ReplaceBoilerplate - A Pod::Weaver bundle for
-    replacing the boilerplate in a Pod document.
+
+    Pod::Weaver::PluginBundle::ReplaceBoilerplate - A Pod::Weaver bundle
+    for replacing the boilerplate in a Pod document.
 
 VERSION
+
     version 1.00_01
 
 OVERVIEW
+
     This is a plugin bundle intended to replace use of [@Default] with
-    equivilent behaviour but with Pod::Weaver::Role::SectionReplacer enabled
-    plugins.
+    equivilent behaviour but with Pod::Weaver::Role::SectionReplacer
+    enabled plugins.
 
     It is nearly equivalent to the following:
 
       [@CorePrep]
-
+    
       [ReplaceName]
       [ReplaceVersion]
-
+    
       [Leftovers]
-
+    
       [ReplaceAuthors]
       [ReplaceLegal]
 
 INSTALLATION
+
     To install this module, run the following commands:
 
       perl Build.PL
@@ -31,6 +35,7 @@ INSTALLATION
       ./Build install
 
 SUPPORT AND DOCUMENTATION
+
     After installing, you can find documentation for this module with the
     perldoc command.
 
@@ -39,26 +44,29 @@ SUPPORT AND DOCUMENTATION
     You can also look for information at:
 
     RT, CPAN's request tracker
-        http://rt.cpan.org/NoAuth/Bugs.html?Dist=Pod-Weaver-PluginBundle-Rep
-        laceBoilerplate
+
+      http://rt.cpan.org/NoAuth/Bugs.html?Dist=Pod-Weaver-PluginBundle-ReplaceBoilerplate
 
     AnnoCPAN, Annotated CPAN documentation
-        http://annocpan.org/dist/Pod-Weaver-PluginBundle-ReplaceBoilerplate
+
+      http://annocpan.org/dist/Pod-Weaver-PluginBundle-ReplaceBoilerplate
 
     CPAN Ratings
-        http://cpanratings.perl.org/d/Pod-Weaver-PluginBundle-ReplaceBoilerp
-        late
+
+      http://cpanratings.perl.org/d/Pod-Weaver-PluginBundle-ReplaceBoilerplate
 
     Search CPAN
-        http://search.cpan.org/dist/Pod-Weaver-PluginBundle-ReplaceBoilerpla
-        te/
+
+      http://search.cpan.org/dist/Pod-Weaver-PluginBundle-ReplaceBoilerplate/
 
 AUTHOR
+
     Sam Graham <libpod-weaver-pluginbundle-replaceboilerplate-perl BLAHBLAH
     illusori.co.uk>
 
 COPYRIGHT AND LICENSE
-    This software is copyright (c) 2010 by Sam Graham
+
+    This software is copyright (c) 2010-2011 by Sam Graham
     <libpod-weaver-pluginbundle-replaceboilerplate-perl BLAHBLAH
     illusori.co.uk>.
 

--- a/lib/Pod/Weaver/PluginBundle/ReplaceBoilerplate.pm
+++ b/lib/Pod/Weaver/PluginBundle/ReplaceBoilerplate.pm
@@ -41,7 +41,7 @@ version 1.00_01
 
 =head1 OVERVIEW
 
-This is a plugin bundle intended to replace use of [@Default] with equivilent
+This is a plugin bundle intended to replace use of [@Default] with equivalent
 behaviour but with L<Pod::Weaver::Role::SectionReplacer> enabled plugins.
 
 It is nearly equivalent to the following:


### PR DESCRIPTION
Hi,

I was assigned this distribution in the CPAN PR challenge (http://neilb.org/2014/11/29/pr-challenge-2015.html ). I've not had a chance to look at the outstanding issue yet (upstream changes to Pod::Weaver::Section::Legal), but here's an initial PR - I've added the missing dependencies (as shown on CPANTS), updated the Pod::Weaver minimum version (to fix a missing DateTime dependency) and regenerated the README and META.yml files. The latest version of Pod::Simple (used by Pod::Readme) formats long lines correctly so the URLs are complete in the README. I've also added the github issues URL so that the link from cpan.org/metacpan.org points here instead of RT.

thanks,
Michael
